### PR TITLE
add find_by_external_tracker() method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,27 @@ This will definitely earn you friends.
         except BugzillaException as e:
             print(e)
 
+Example: Searching with an upstream bug
+---------------------------------------
+
+Quickly find out "What BZ matches this external tracker ticket?"
+
+.. code-block:: python
+
+    from txbugzilla import connect, BugzillaException
+    from twisted.internet import defer
+
+    def example():
+        bz = yield connect()
+        try:
+            result = yield bz.find_by_external_tracker(
+                'http://tracker.ceph.com', '16673')
+            for b in result:
+                print(b.weburl + ' ' + b.summary)
+        except BugzillaException as e:
+            print(e)
+
+
 Example: Raw XML-RPC calls
 --------------------------
 

--- a/txbugzilla/__init__.py
+++ b/txbugzilla/__init__.py
@@ -131,6 +131,29 @@ class Connection(object):
         d.addCallback(self._parse_bug_assigned_callback)
         return d
 
+    def find_by_external_tracker(self, url, id_):
+        """
+        Find a list of bugs by searching an external tracker URL and ID.
+
+        param url: ``str``, the external ticket URL, eg
+                   "http://tracker.ceph.com". (Note this is the base URL.)
+        param id_: ``str``, the external ticket ID, eg "18812".
+        returns: deferred that when fired returns a list of ``AttrDict``s
+                 representing these bugs.
+        """
+        payload = {
+            'include_fields': ['id', 'summary', 'status'],
+            'f1': 'external_bugzilla.url',
+            'o1': 'equals',
+            'v1': url,
+            'f2': 'ext_bz_bug_map.ext_bz_bug_id',
+            'o2': 'equals',
+            'v2': id_,
+        }
+        d = self.call('Bug.search', payload)
+        d.addCallback(self._parse_bugs_callback)
+        return d
+
     def _parse_bug_callback(self, value):
         """
         Fires when we get bug information back from the XML-RPC server.

--- a/txbugzilla/tests/test_find_by_external_tracker.py
+++ b/txbugzilla/tests/test_find_by_external_tracker.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+from txbugzilla import connect
+from twisted.internet import defer
+
+
+class _StubProxy(object):
+    def __init__(self, url):
+        pass
+
+    def callRemote(self, action, payload):
+        """ Return a deferred that always fires successfully """
+        assert action == 'Bug.search'
+        result = {'bugs': [{
+            'id': 1422893,
+            'status': 'ASSIGNED',
+            'summary': '[RFE] rgw: add suport for Swift-at-root',
+            'weburl': 'https://bugzilla.redhat.com/1422893',
+        }]}
+        return defer.succeed(result)
+
+
+class TestFindByExternalTracker(object):
+
+    @pytest.inlineCallbacks
+    def test_find_by_external_tracker(self, monkeypatch):
+        monkeypatch.setenv('HOME', os.getcwd())
+        monkeypatch.setattr('txbugzilla.Proxy', _StubProxy)
+
+        external_tracker_url = 'http://tracker.ceph.com'
+        external_tracker_id = '16673'
+
+        bz = yield connect()
+        result = yield bz.find_by_external_tracker(external_tracker_url,
+                                                   external_tracker_id)
+        assert len(result) == 1
+        assert result[0].id == 1422893


### PR DESCRIPTION
This is useful for quickly answering "Which BZ corresponds to this upstream tracker ID?"