### PR TITLE
fix _parse_bugs_callback() on py3

### DIFF
--- a/txbugzilla/__init__.py
+++ b/txbugzilla/__init__.py
@@ -172,7 +172,7 @@ class Connection(object):
                      contains a list of bugs.
         returns: ``list`` of ``AttrDict``
         """
-        return map(lambda x: self._parse_bug(x), value['bugs'])
+        return list(map(lambda x: self._parse_bug(x), value['bugs']))
 
     def _parse_bug_assigned_callback(self, value):
         """


### PR DESCRIPTION
In Python 3, `map()` returns a `map` type, rather than a `list`.

Explicitly return a `list` from our callback here, so we have the same behavior in py2 and py3.