### PR TITLE
token_from_file: load from newer cache location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .test
 .testrepository
 .tox
-.cache
+/.cache
 .coverage
 build/*
 dist/*

--- a/README.rst
+++ b/README.rst
@@ -100,21 +100,22 @@ And then, to re-use this token later:
         yield bz.assign(1234, 'someone@redhat.com')
 
 
-Side note: ~/.bugzillatoken
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Side note: bugzillatoken
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you pass no parameters to ``connect()``, the resulting connection will be
-anonymous *unless* you have a special ``.bugzillatoken`` file in your home
-directory. This file should look something like this::
+anonymous *unless* you have a special ``.cache/python-bugzilla/bugzillatoken``
+file in your home directory. This file should look something like this::
 
-    $ cat ~/.bugzillatoken
+    $ cat ~/.cache/python-bugzilla/bugzillatoken
     [bugzilla.redhat.com]
     token = 123456-abcdef987
 
 txbugzilla will look for this file and attempt to use the token there if one
-exists.
+exists. (It will also fall back to checking the older ``~/.bugzillatoken``
+location, if the ``~/.cache`` one is unavailable.)
 
-To construct this ``.bugzillatoken`` file, you can use the `python-bugzilla
+To construct this ``bugzillatoken`` file, you can use the `python-bugzilla
 <https://pypi.python.org/pypi/python-bugzilla>`_ module, like so::
 
     $ pip install python-bugzilla

--- a/txbugzilla/__init__.py
+++ b/txbugzilla/__init__.py
@@ -43,15 +43,19 @@ def login_callback(value, url, username):
 
 def token_from_file(url):
     """ Check ~/.bugzillatoken for a token for this Bugzilla URL. """
-    path = os.path.expanduser('~/.bugzillatoken')
-    cfg = SafeConfigParser()
-    cfg.read(path)
-    domain = urlparse(url)[1]
-    if domain not in cfg.sections():
-        return None
-    if not cfg.has_option(domain, 'token'):
-        return None
-    return cfg.get(domain, 'token')
+    locations = [
+        os.path.expanduser('~/.cache/python-bugzilla/bugzillatoken'),
+        os.path.expanduser('~/.bugzillatoken'),
+    ]
+    for path in locations:
+        cfg = SafeConfigParser()
+        cfg.read(path)
+        domain = urlparse(url)[1]
+        if domain not in cfg.sections():
+            continue
+        if not cfg.has_option(domain, 'token'):
+            continue
+        return cfg.get(domain, 'token')
 
 
 class Connection(object):

--- a/txbugzilla/tests/fixtures/home-cache-token/.cache/python-bugzilla/bugzillatoken
+++ b/txbugzilla/tests/fixtures/home-cache-token/.cache/python-bugzilla/bugzillatoken
@@ -1,0 +1,2 @@
+[bugzilla.example.com]
+token = abc-123-cache

--- a/txbugzilla/tests/fixtures/home-legacy-token/.bugzillatoken
+++ b/txbugzilla/tests/fixtures/home-legacy-token/.bugzillatoken
@@ -1,0 +1,2 @@
+[bugzilla.example.com]
+token = abc-123-legacy

--- a/txbugzilla/tests/test_token_from_file.py
+++ b/txbugzilla/tests/test_token_from_file.py
@@ -1,0 +1,19 @@
+import os
+from txbugzilla import token_from_file
+
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
+
+
+URL = 'https://bugzilla.example.com/xmlrpc.cgi'
+
+
+def test_token_from_file_legacy(monkeypatch):
+    monkeypatch.setenv('HOME', FIXTURES_DIR + '/home-legacy-token')
+    assert token_from_file(URL) == 'abc-123-legacy'
+
+
+def test_token_from_file_cache(monkeypatch):
+    monkeypatch.setenv('HOME', FIXTURES_DIR + '/home-cache-token')
+    assert token_from_file(URL) == 'abc-123-cache'


### PR DESCRIPTION
Modern versions of python-bugzilla store the token in `~/.cache/python-bugzilla/bugzillatoken`. Look in this location first.